### PR TITLE
Handle filenames with spaces

### DIFF
--- a/LATS_demo.ipynb
+++ b/LATS_demo.ipynb
@@ -255,7 +255,7 @@
         "visuals = model.inference(data)\n",
         "\n",
         "os.makedirs('results', exist_ok=True)\n",
-        "out_path = os.path.join('results', os.path.splitext(img_path)[0] + '.mp4')\n",
+        "out_path = os.path.join('results', os.path.splitext(img_path)[0].replace(' ', '_') + '.mp4')\n",
         "visualizer.make_video(visuals, out_path)"
       ],
       "execution_count": null,
@@ -287,7 +287,7 @@
         "# result to webm for display purposes\n",
         "\n",
         "# !pip3 install webm\n",
-        "# webm_out_path = os.path.join('results', os.path.splitext(img_path)[0] + '.webm')\n",
+        "# webm_out_path = os.path.join('results', os.path.splitext(img_path)[0].replace(' ', '_') + '.webm')\n",
         "# !webm -i $out_path $webm_out_path\n",
         "# use_webm = True\n",
         "\n",


### PR DESCRIPTION
When using a filename with a space on Chrome (and hence uncommenting the webm part), I got the following error:

```
webm: error: unrecognized arguments: results/demo test.webm
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-29-5e27c289b4c1> in <module>()
     13 video_path = webm_out_path if use_webm else out_path
     14 video_type = "video/webm" if use_webm else "video/mp4"
---> 15 mp4 = open(video_path,'rb').read()
     16 data_url = "data:video/mp4;base64," + b64encode(mp4).decode()
     17 HTML("""

FileNotFoundError: [Errno 2] No such file or directory: 'results/demo test.webm'
```

This PR replaces spaces in a filename with underscores.