### PR TITLE
Added missing dependency dlib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow
 unidecode
 requests
 tqdm
+dlib


### PR DESCRIPTION
After running pip install -r requirements.txt and ./run_scripts/in_the_wild.sh, got a "missing dlib module" error.
Adding dlib to requirements.txt fixes the issue.